### PR TITLE
Update parser.go, fix parser bug.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -236,7 +236,7 @@ func (p *Parser) parseExpr() (Expr, error) {
 		}
 
 		// Assign the new root based on the precendence of the LHS and RHS operators.
-		if lhs, ok := expr.(*BinaryExpr); ok && lhs.Op.Precedence() <= op.Precedence() {
+		if lhs, ok := expr.(*BinaryExpr); ok && lhs.Op.Precedence() < op.Precedence() {
 			expr = &BinaryExpr{
 				LHS: lhs.LHS,
 				RHS: &BinaryExpr{LHS: lhs.RHS, RHS: rhs, Op: op},


### PR DESCRIPTION
Old code would parse formula like "[A] == [B] AND [A] == 3 AND [B] == 3" to "(A == B AND A == 3 AND B) == 3".
Fixit.